### PR TITLE
Add experimental android-emu-atd image (GMD, ATD API 30+34)

### DIFF
--- a/.github/workflows/android-emu-atd.yml
+++ b/.github/workflows/android-emu-atd.yml
@@ -1,0 +1,17 @@
+# Кладётся в android-docker-images как .github/workflows/android-emu-atd.yml
+# Использует их reusable publish-image.yml (context по умолчанию = image-name → ./android-emu-atd/).
+# platforms=linux/amd64: эмулятор и ATD-образы — x86/x86_64, arm64 не нужен.
+name: Android Emulator ATD Image
+on: workflow_dispatch
+
+jobs:
+  android-emu-atd:
+    name: Publish Android Emulator ATD image (GMD)
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      image-name: android-emu-atd
+      title: Android Emulator ATD image (GMD, API 30 + 34)
+      platforms: linux/amd64
+      tags: |
+        34
+        34-{{date 'YYYYMMDD'}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### android-emu-atd
+
+- Add experimental `android-emu-atd:34` image — Android emulator for instrumented tests via Gradle Managed Devices (AOSP ATD system images API 30 + 34, emulator runtime libs). Unlike `android-emu`, does not bake an AVD/snapshot; GMD manages the emulator lifecycle.
+
 ## [2024.02.24]
 
 ### android-sdk

--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ Ruby image with some additions to work with Fastlane and Danger.
 
 - [Allurectl][allurectl] - command line wrapper of Allure TestOps' API allowing you to upload the test results in real time from a build job, and managing entities on Allure TestOps side (test cases, launches, projects).
 
+### android-emu-atd
+
+> `ghcr.io/redmadrobot/android/android-emu-atd:34`
+
+**Base image**: `android-sdk:34` \
+**Platforms:** `linux/amd64`
+
+Image for instrumented (UI) tests run via **Gradle Managed Devices (GMD)**.
+Unlike `android-emu` (manual model: baked AVD + snapshot + `start-emulator`, `google_apis`,
+one API per image), this image does **not** bake an AVD or snapshot — the GMD Gradle task
+manages the emulator lifecycle. It only adds what stock `android-sdk` lacks:
+
+- emulator runtime shared libraries (`libX11` etc. — the launcher fails to start without them);
+- the `emulator` package;
+- AOSP **ATD** system images (headless-optimized, no Google APIs):
+  `system-images;android-30;aosp_atd;x86` and `system-images;android-34;aosp_atd;x86_64`.
+
+A single image carries both API levels so it serves the whole GMD matrix from one `image:`.
+The API levels must match `apiLevel` in the consuming project's Gradle Managed Devices config.
+
+> [!Note]
+>
+> Hardware acceleration (`/dev/kvm`) is **not** part of the image — it is a device passthrough
+> configured on the runner. The emulator needs it at runtime.
+
 ### danger-kotlin:[x]
 
 > `ghcr.io/redmadrobot/android/danger-kotlin:1.0.0` \

--- a/android-emu-atd/Dockerfile
+++ b/android-emu-atd/Dockerfile
@@ -19,6 +19,7 @@ FROM ghcr.io/redmadrobot/android/android-sdk:34
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN <<EOF
+  set -eu
   # Рантайм-либы эмулятора: без libX11.so.6 лаунчер падает на старте (error loading shared libraries).
   apt-get update --yes
   apt-get install --yes --no-install-recommends \
@@ -29,6 +30,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
+  set -eu
   # Пакет emulator + ATD system-images под матрицу GMD. Лицензии принимаются здесь же.
   yes | sdkmanager --licenses > /dev/null
   yes | sdkmanager \
@@ -39,6 +41,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
+  set -eu
   # Build-time sanity: лаунчер линкуется без missing-libs.
   # (accel-check требует /dev/kvm в рантайме — здесь проверяем только целостность либ.)
   "$ANDROID_HOME/emulator/emulator" -version | head -1

--- a/android-emu-atd/Dockerfile
+++ b/android-emu-atd/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+#
+# android-emu-atd — CI-образ для instrumented (UI) тестов через Gradle Managed Devices (GMD).
+#
+# В отличие от experimental `android-emu` (ручная модель: запечённый AVD + snapshot +
+# start-emulator, google_apis, один API на образ) — этот образ НЕ бейкает AVD/snapshot:
+# lifecycle эмулятора управляет сама GMD-задача (`:app:ciAtdDebugAndroidTest`). Образ лишь
+# докладывает то, чего нет в android-sdk:34 — рантайм-либы, пакет `emulator` и ATD-образы.
+# Один образ несёт ОБА уровня матрицы (30 x86 + 34 x86_64), чтобы обслуживать её из одного `image:`.
+#
+# ATD (Automated Test Device) — headless-оптимизированные образы без Google APIs.
+# /dev/kvm сюда не входит — это проброс устройства на раннере (тег `android`), не часть образа.
+#
+# Список system-images должен совпадать с apiLevel в проекте
+# (app/build.gradle.kts → testOptions.managedDevices: ciAtd=30, ciAtd34=34).
+
+FROM ghcr.io/redmadrobot/android/android-sdk:34
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN <<EOF
+  # Рантайм-либы эмулятора: без libX11.so.6 лаунчер падает на старте (error loading shared libraries).
+  apt-get update --yes
+  apt-get install --yes --no-install-recommends \
+    libx11-6 libx11-xcb1 libxcb1 libxext6 libxdamage1 libxfixes3 \
+    libxcomposite1 libxcursor1 libxi6 libxrender1 libxtst6 \
+    libnss3 libnspr4 libpulse0 libasound2 libgl1
+  rm -rf /var/lib/apt/lists/*
+EOF
+
+RUN <<EOF
+  # Пакет emulator + ATD system-images под матрицу GMD. Лицензии принимаются здесь же.
+  yes | sdkmanager --licenses > /dev/null
+  yes | sdkmanager \
+    "emulator" \
+    "system-images;android-30;aosp_atd;x86" \
+    "system-images;android-34;aosp_atd;x86_64"
+  rm -rf "$ANDROID_USER_HOME/cache"
+EOF
+
+RUN <<EOF
+  # Build-time sanity: лаунчер линкуется без missing-libs.
+  # (accel-check требует /dev/kvm в рантайме — здесь проверяем только целостность либ.)
+  "$ANDROID_HOME/emulator/emulator" -version | head -1
+  if ldd "$ANDROID_HOME/emulator/emulator" | grep -q "not found"; then
+    echo "ERROR: emulator has missing shared libraries" >&2
+    ldd "$ANDROID_HOME/emulator/emulator" | grep "not found" >&2
+    exit 1
+  fi
+  echo "emulator libs OK"
+EOF


### PR DESCRIPTION
## Что

Новый experimental-образ **`android-emu-atd`** для instrumented (UI) тестов через **Gradle Managed Devices (GMD)**.

Расширяет `android-sdk:34`:
- рантайм-либы эмулятора (без `libX11.so.6` лаунчер не стартует);
- пакет `emulator`;
- AOSP **ATD** system-images (headless, без Google APIs): `android-30;aosp_atd;x86` и `android-34;aosp_atd;x86_64`.

## Чем отличается от существующего `android-emu`

`android-emu` — ручная модель (запечённый AVD + snapshot + `start-emulator`, `google_apis`, один API на образ). `android-emu-atd` заточен под GMD: AVD/snapshot и lifecycle эмулятора ведёт сама gradle-задача, поэтому образ их **не** бейкает. Легче (ATD вместо google_apis), один образ несёт оба уровня матрицы (30 + 34) → обслуживает всю GMD-матрицу из одного `image:`.

## Файлы
- `android-emu-atd/Dockerfile` (в стиле репо: `# syntax`, heredoc, `--no-install-recommends`, чистка кэшей, build-time sanity на missing-libs)
- `.github/workflows/android-emu-atd.yml` (через reusable `publish-image.yml`, `platforms: linux/amd64`, дата-теги)
- README (раздел Experimental) + CHANGELOG (Unreleased)

## Заметки
- `/dev/kvm` в образ не входит — это проброс устройства на раннере (нужен в рантайме).
- API-уровни в Dockerfile должны совпадать с `apiLevel` GMD-конфига в потребляющем проекте.

🤖 Generated with [Claude Code](https://claude.com/claude-code)