### PR TITLE
Add android-sdk:36 image with build-tools 36.0.0

### DIFF
--- a/.github/workflows/android-emu-atd.yml
+++ b/.github/workflows/android-emu-atd.yml
@@ -1,6 +1,7 @@
 # Кладётся в android-docker-images как .github/workflows/android-emu-atd.yml
 # Использует их reusable publish-image.yml (context по умолчанию = image-name → ./android-emu-atd/).
 # platforms=linux/amd64: эмулятор и ATD-образы — x86/x86_64, arm64 не нужен.
+# Тег образа = версия базового android-sdk (36), а не API уровень ATD-образов (внутри 30 + 34).
 name: Android Emulator ATD Image
 on: workflow_dispatch
 
@@ -10,8 +11,8 @@ jobs:
     uses: ./.github/workflows/publish-image.yml
     with:
       image-name: android-emu-atd
-      title: Android Emulator ATD image (GMD, API 30 + 34)
+      title: Android Emulator ATD image (GMD, base android-sdk:36, ATD API 30 + 34)
       platforms: linux/amd64
       tags: |
-        34
-        34-{{date 'YYYYMMDD'}}
+        36
+        36-{{date 'YYYYMMDD'}}

--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -80,3 +80,39 @@ jobs:
         sdk=docker-image://${{ needs.env.outputs.image-path }}:${{ matrix.sdk }}
       build-args: |
         ndk=${{ needs.env.outputs.ndk }}
+
+  # Android SDK 36 pipeline.
+  # Android Gradle Plugin requires build-tools 36.0.0+ for compileSdk 36, so this pipeline
+  # builds its own base image variant with build-tools 36.0.0 instead of the default 34.0.0.
+  # Images published by the jobs above keep build-tools 34.0.0 and are not affected.
+  android-sdk-base-36:
+    name: Publish Android SDK base image with build-tools 36.0.0
+    needs: env
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      image-name: ${{ needs.env.outputs.image-name }}
+      target: base
+      platforms: linux/amd64,linux/arm64
+      title: Android SDK base image with build-tools 36.0.0
+      tags: |
+        base-36.0.0
+        base-36.0.0-{{date 'YYYYMMDD'}}
+      build-args: |
+        build_tools=36.0.0
+
+  android-sdk-36:
+    name: Publish Android SDK 36 image
+    needs: [ android-sdk-base-36, env ]
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      image-name: ${{ needs.env.outputs.image-name }}
+      target: sdk
+      platforms: linux/amd64,linux/arm64
+      title: Android SDK 36 image
+      tags: |
+        36
+        36-{{date 'YYYYMMDD'}}
+      build-contexts: |
+        base=docker-image://${{ needs.env.outputs.image-path }}:base-36.0.0
+      build-args: |
+        sdk=36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## [Unreleased]
 
+### android-sdk
+
+- Add image for Android SDK 36 (Android 16): `android-sdk:36`
+- Add base image variant `base-36.0.0` with build-tools `36.0.0` — required by Android Gradle Plugin for `compileSdk = 36`. `android-sdk:36` is built on top of it
+- Existing images are not affected: `base` and `32`, `33`, `34` (including `-ndk` tags) keep build-tools `34.0.0`
+
 ### android-emu-atd
 
-- Add experimental `android-emu-atd:34` image — Android emulator for instrumented tests via Gradle Managed Devices (AOSP ATD system images API 30 + 34, emulator runtime libs). Unlike `android-emu`, does not bake an AVD/snapshot; GMD manages the emulator lifecycle.
+- Add experimental `android-emu-atd:36` image — Android emulator for instrumented tests via Gradle Managed Devices (AOSP ATD system images API 30 + 34, emulator runtime libs). Unlike `android-emu`, does not bake an AVD/snapshot; GMD manages the emulator lifecycle
+- :exclamation: Base image `android-sdk:34` → `android-sdk:36`. The published tag is renamed `34` → `36` accordingly: the tag denotes the base `android-sdk` version, not an ATD API level. Bundled ATD system images are unchanged (API 30 + 34)
 
 ## [2024.02.24]
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,23 @@ All images are published in [GitHub Container Registry][ghcr].
 >
 > You should always align build-tools and compile SDK in your project to match the versions used in image, otherwise Android Gradle Plugin will download `build-tools` and `platform` packages in each CI build.
 >
+> The build-tools version depends on the image tag: `android-sdk:36` ships build-tools **36.0.0**, `android-sdk:34`, `:33` and `:32` ship build-tools **34.0.0**.
+>
 > ```kotlin
 > android {
->     buildToolsVersion = "34.0.0"
+>     // 36.0.0 for android-sdk:36, 34.0.0 for android-sdk:34, :33 and :32
+>     buildToolsVersion = "36.0.0"
 >     compileSdk = [x]
 > }
 > ```
 
 ### android-sdk:base
 
-> `ghcr.io/redmadrobot/android/android-sdk:base`
+> `ghcr.io/redmadrobot/android/android-sdk:base` \
+> `ghcr.io/redmadrobot/android/android-sdk:base-36.0.0`
 
 Base Android image. All other android images are built on top of this image.
+There are two variants, they differ only in the build-tools version.
 
 **Base image**: `eclipse-temurin:17-jdk-jammy` \
 **Platforms:** `linux/amd64`, `linux/arm64` \
@@ -36,11 +41,16 @@ Base Android image. All other android images are built on top of this image.
 
 - sdkmanager:
     - cmdline-tools **12.0**
-    - build-tools **34.0.0**
-    - platform-tools **35.0.0**
+    - build-tools **34.0.0** in `base`, **36.0.0** in `base-36.0.0`
+    - platform-tools — not pinned, an image gets the release current at its build time (**35.0.0** in the published `base`)
 - python3 **3.10**
 - git
 - zip, unzip
+
+**Tags:**
+
+- `base` — build-tools **34.0.0**, used by `android-sdk:34`, `:33`, `:32`
+- `base-36.0.0` — build-tools **36.0.0**, used by `android-sdk:36`
 
 <details>
 <summary>Deprecated tags</summary>
@@ -58,6 +68,7 @@ It should match your `compileSdk` in project build script.
 
 **Tags:**
 
+- `36` (Android 16) — built on `base-36.0.0`, build-tools **36.0.0**
 - `34` (Android 14)
 - `33` (Android 13)
 - `32` (Android 12L)
@@ -164,10 +175,15 @@ Ruby image with some additions to work with Fastlane and Danger.
 
 ### android-emu-atd
 
-> `ghcr.io/redmadrobot/android/android-emu-atd:34`
+> `ghcr.io/redmadrobot/android/android-emu-atd:36`
 
-**Base image**: `android-sdk:34` \
+**Base image**: `android-sdk:36` \
 **Platforms:** `linux/amd64`
+
+> [!Note]
+>
+> The image tag is the version of the base `android-sdk` image, **not** an ATD API level.
+> `android-emu-atd:36` is built on `android-sdk:36` and carries ATD system images for API **30** and **34**.
 
 Image for instrumented (UI) tests run via **Gradle Managed Devices (GMD)**.
 Unlike `android-emu` (manual model: baked AVD + snapshot + `start-emulator`, `google_apis`,

--- a/android-emu-atd/Dockerfile
+++ b/android-emu-atd/Dockerfile
@@ -5,7 +5,7 @@
 # В отличие от experimental `android-emu` (ручная модель: запечённый AVD + snapshot +
 # start-emulator, google_apis, один API на образ) — этот образ НЕ бейкает AVD/snapshot:
 # lifecycle эмулятора управляет сама GMD-задача (`:app:ciAtdDebugAndroidTest`). Образ лишь
-# докладывает то, чего нет в android-sdk:34 — рантайм-либы, пакет `emulator` и ATD-образы.
+# докладывает то, чего нет в android-sdk:36 — рантайм-либы, пакет `emulator` и ATD-образы.
 # Один образ несёт ОБА уровня матрицы (30 x86 + 34 x86_64), чтобы обслуживать её из одного `image:`.
 #
 # ATD (Automated Test Device) — headless-оптимизированные образы без Google APIs.
@@ -14,7 +14,7 @@
 # Список system-images должен совпадать с apiLevel в проекте
 # (app/build.gradle.kts → testOptions.managedDevices: ciAtd=30, ciAtd34=34).
 
-FROM ghcr.io/redmadrobot/android/android-sdk:34
+FROM ghcr.io/redmadrobot/android/android-sdk:36
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Why

Consumers with `compileSdk = 36` (AGP requires build-tools 36.0.0+) currently run on
`android-sdk:34`, which bakes build-tools `34.0.0` and platform `android-34`. As a result
every CI job downloads and installs Build-Tools 36.0.0 and Platform 36 from scratch —
confirmed in job traces: "Installing Android SDK Build-Tools 36 in
/opt/android-sdk/build-tools/36.0.0", "Installing Android SDK Platform 36 in
/opt/android-sdk/platforms/android-36" (188 MB + 134 MB on disk). `/opt/android-sdk` is not
part of the job cache, so this repeats on every run. This is exactly what the README warns
about in the `android-sdk` section. ghcr currently has no `35`/`36` tag — `34` is the newest.

## What

- New job `android-sdk-base-36`: `target: base` with `build_tools=36.0.0`, published as
  `base-36.0.0` / `base-36.0.0-YYYYMMDD` (linux/amd64, linux/arm64).
- New job `android-sdk-36`: `target: sdk`, `sdk=36`, built on the pinned base via
  `build-contexts: base=docker-image://…:base-36.0.0`, published as `36` / `36-YYYYMMDD`.
- `android-emu-atd` moved onto `android-sdk:36` and retagged `36` accordingly.
- README and CHANGELOG updated.

## The change is strictly additive

`build_tools` is installed in the shared `base` stage, so the default
`ARG build_tools="34.0.0"` is left untouched and the install is **not** moved out of `base`.
Existing jobs `android-sdk-base`, `android-sdk` and `android-sdk-ndk` are byte-identical:
zero removed lines in `.github/workflows/android-sdk.yml`. Tags `base`, `32`, `33`, `34`
and all `*-ndk` tags keep build-tools `34.0.0` and behave exactly as before. No existing
consumer changes.

## Verification

- `build-tools;36.0.0` and `platforms;android-36` are present in **all** of Google's
  repository manifests (`repository2-1.xml` … `repository2-4.xml`), so the baked
  cmdline-tools **12.0** resolves them — no cmdline-tools bump needed for this change.
- Both workflows parse; all `with:` keys of the new jobs are within the
  `publish-image.yml` input contract.
- **Not built locally** — docker was unavailable in the prep environment. The first CI
  dispatch is the actual proof.

## Notes for the maintainer

- **Dispatch order after merge:** run `Android SDK Images` first (publishes `base-36.0.0`
  and `36`), then `Android Emulator ATD Image`. The ATD build cannot resolve
  `android-sdk:36` at its `FROM` until the first run completes.
- `android-sdk.yml` is `on: workflow_dispatch` with no per-job filter, so dispatching it to
  publish `36` also republishes `base`, `32`/`33`/`34` and every `-ndk` tag with fresh
  `-YYYYMMDD` tags (and a newer, unpinned `platform-tools`). A gating input was deliberately
  not added, to keep this change additive — flagging it as a dispatch side effect only.
- `android-emu-atd:34` and `34-20260729` remain in the registry, so nothing breaks
  retroactively, but consumers pinning `:34` must switch to `:36` in a follow-up MR
  (`android/shared-libraries` CI `image:`).

## Deliberately out of scope

- cmdline-tools 12.0 → newer (needs a new sha256 plus `cmdline-tools-package.xml` update,
  nothing here to verify it against).
- `36-ndk`, removing `libncurses5`, pinning `platform-tools`.
- `.gitlab-ci.yml` — dead: `only: master` while the default branch is `main`, references
  non-existent `android-sdk/sdk/Dockerfile` and `android-sdk/ndk/Dockerfile`, ruby 2.7/3.0,
  NDK 25.1. Publishing happens only via GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
