### PR TITLE
Single base image with build-tools 36.0.0 (review follow-up for #21)

### DIFF
--- a/.github/workflows/android-emu-atd.yml
+++ b/.github/workflows/android-emu-atd.yml
@@ -1,7 +1,6 @@
-# Кладётся в android-docker-images как .github/workflows/android-emu-atd.yml
-# Использует их reusable publish-image.yml (context по умолчанию = image-name → ./android-emu-atd/).
-# platforms=linux/amd64: эмулятор и ATD-образы — x86/x86_64, arm64 не нужен.
-# Тег образа = версия базового android-sdk (36), а не API уровень ATD-образов (внутри 30 + 34).
+# platforms=linux/amd64: the emulator and ATD system images are x86/x86_64, arm64 is not needed.
+# The image tag is the base android-sdk version (36), not the API level of the bundled
+# ATD system images (30 + 34).
 name: Android Emulator ATD Image
 on: workflow_dispatch
 

--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [ android-sdk-base, env ]
     strategy:
       matrix:
-        sdk: [ 32, 33, 34 ]
+        sdk: [ 34, 35, 36 ]
     uses: ./.github/workflows/publish-image.yml
     with:
       image-name: ${{ needs.env.outputs.image-name }}
@@ -65,7 +65,7 @@ jobs:
     needs: [ android-sdk, env ]
     strategy:
       matrix:
-        sdk: [ 32, 33, 34 ]
+        sdk: [ 34, 35, 36 ]
     uses: ./.github/workflows/publish-image.yml
     with:
       image-name: ${{ needs.env.outputs.image-name }}
@@ -80,39 +80,3 @@ jobs:
         sdk=docker-image://${{ needs.env.outputs.image-path }}:${{ matrix.sdk }}
       build-args: |
         ndk=${{ needs.env.outputs.ndk }}
-
-  # Android SDK 36 pipeline.
-  # Android Gradle Plugin requires build-tools 36.0.0+ for compileSdk 36, so this pipeline
-  # builds its own base image variant with build-tools 36.0.0 instead of the default 34.0.0.
-  # Images published by the jobs above keep build-tools 34.0.0 and are not affected.
-  android-sdk-base-36:
-    name: Publish Android SDK base image with build-tools 36.0.0
-    needs: env
-    uses: ./.github/workflows/publish-image.yml
-    with:
-      image-name: ${{ needs.env.outputs.image-name }}
-      target: base
-      platforms: linux/amd64,linux/arm64
-      title: Android SDK base image with build-tools 36.0.0
-      tags: |
-        base-36.0.0
-        base-36.0.0-{{date 'YYYYMMDD'}}
-      build-args: |
-        build_tools=36.0.0
-
-  android-sdk-36:
-    name: Publish Android SDK 36 image
-    needs: [ android-sdk-base-36, env ]
-    uses: ./.github/workflows/publish-image.yml
-    with:
-      image-name: ${{ needs.env.outputs.image-name }}
-      target: sdk
-      platforms: linux/amd64,linux/arm64
-      title: Android SDK 36 image
-      tags: |
-        36
-        36-{{date 'YYYYMMDD'}}
-      build-contexts: |
-        base=docker-image://${{ needs.env.outputs.image-path }}:base-36.0.0
-      build-args: |
-        sdk=36

--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -44,6 +44,7 @@ jobs:
     name: Publish Android SDK image
     needs: [ android-sdk-base, env ]
     strategy:
+      fail-fast: false
       matrix:
         sdk: [ 34, 35, 36 ]
     uses: ./.github/workflows/publish-image.yml
@@ -64,6 +65,7 @@ jobs:
     name: Publish Android SDK image with NDK
     needs: [ android-sdk, env ]
     strategy:
+      fail-fast: false
       matrix:
         sdk: [ 34, 35, 36 ]
     uses: ./.github/workflows/publish-image.yml

--- a/.run/android-sdk_x-ndk.run.xml
+++ b/.run/android-sdk_x-ndk.run.xml
@@ -7,11 +7,11 @@
           <list>
             <DockerEnvVarImpl>
               <option name="name" value="sdk" />
-              <option name="value" value="33" />
+              <option name="value" value="36" />
             </DockerEnvVarImpl>
             <DockerEnvVarImpl>
               <option name="name" value="ndk" />
-              <option name="value" value="25.1.8937393" />
+              <option name="value" value="26.2.11394342" />
             </DockerEnvVarImpl>
           </list>
         </option>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ### android-sdk
 
 - Add image for Android SDK 36 (Android 16): `android-sdk:36`
-- Add base image variant `base-36.0.0` with build-tools `36.0.0` — required by Android Gradle Plugin for `compileSdk = 36`. `android-sdk:36` is built on top of it
-- Existing images are not affected: `base` and `32`, `33`, `34` (including `-ndk` tags) keep build-tools `34.0.0`
+- Add image for Android SDK 35 (Android 15): `android-sdk:35`
+- :exclamation: Update build-tools `34.0.0` → `36.0.0` in `base`. All `android-sdk` tags now ship the same build-tools version — newer build-tools can build for lower compile SDK levels. Android Gradle Plugin 9.2.x requires `36.0.0` and downloads it on every build otherwise
+- :exclamation: SDK 32 and 33 images archived and will not be updated anymore. Only the three latest SDK versions are published
+- Remove base image variant `base-36.0.0` — superseded by the build-tools update in `base`
 
 ### android-emu-atd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### android-sdk
 
-- Add image for Android SDK 36 (Android 16): `android-sdk:36`
-- Add image for Android SDK 35 (Android 15): `android-sdk:35`
-- :exclamation: Update build-tools `34.0.0` → `36.0.0` in `base`. All `android-sdk` tags now ship the same build-tools version — newer build-tools can build for lower compile SDK levels. Android Gradle Plugin 9.2.x requires `36.0.0` and downloads it on every build otherwise
-- :exclamation: SDK 32 and 33 images archived and will not be updated anymore. Only the three latest SDK versions are published
+- Add image for Android SDK 36 (Android 16): `android-sdk:36`, `android-sdk:36-ndk`
+- Add image for Android SDK 35 (Android 15): `android-sdk:35`, `android-sdk:35-ndk`
+- :exclamation: Update build-tools `34.0.0` → `36.0.0` in `base`. All rebuilt `android-sdk` tags (`34`, `35`, `36`) now ship the same build-tools version — newer build-tools can build for lower compile SDK levels; archived `32`/`33` tags and earlier `34` dated tags keep `34.0.0`. Android Gradle Plugin 9.2.x requires `36.0.0` and downloads it on every build otherwise. If your project does not declare `buildToolsVersion` at all, add `buildToolsVersion = "36.0.0"` — AGP below 9.2 defaults to a version that is no longer in the image
+- :exclamation: SDK 32 and 33 images archived and will not be updated anymore, including their `-ndk` variants. Only the three latest SDK versions are published
 - Remove base image variant `base-36.0.0` — superseded by the build-tools update in `base`
 
 ### android-emu-atd

--- a/README.md
+++ b/README.md
@@ -17,16 +17,20 @@ All images are published in [GitHub Container Registry][ghcr].
 >
 > You should always align build-tools and compile SDK in your project to match the versions used in image, otherwise Android Gradle Plugin will download `build-tools` and `platform` packages in each CI build.
 >
-> All `android-sdk` tags ship the same build-tools **36.0.0** — newer build-tools can build for lower compile SDK levels.
+> Tags rebuilt from this update onwards (`34`, `35`, `36`) ship the same build-tools **36.0.0** — newer build-tools can build for lower compile SDK levels. Archived `32`/`33` tags and earlier `34` dated tags keep build-tools **34.0.0**.
+>
+> Every image exports the version it ships as `ANDROID_BUILD_TOOLS_VERSION`, so a project can follow the image it runs on instead of hardcoding a version. The fallback keeps builds outside the image working:
 >
 > ```kotlin
 > android {
->     buildToolsVersion = "36.0.0"
+>     buildToolsVersion = System.getenv("ANDROID_BUILD_TOOLS_VERSION") ?: "36.0.0"
 >     compileSdk = [x]
 > }
 > ```
 >
 > Keep in mind that Android Gradle Plugin ignores `buildToolsVersion` below its own minimum and downloads its default version instead. AGP 9.2.x defaults to build-tools **36.0.0**.
+>
+> If your project does not declare `buildToolsVersion` at all, add it — AGP below 9.2 defaults to a version that is no longer in the image and downloads it on every build.
 
 ### android-sdk:base
 
@@ -97,13 +101,15 @@ android {
 
 **Tags:**
 
-- `34-ndk`, `33-ndk-26.2.11394342`
-- `33-ndk`, `33-ndk-26.2.11394342`
-- `32-ndk`, `32-ndk-26.2.11394342`
+- `36-ndk`, `36-ndk-26.2.11394342`
+- `35-ndk`, `35-ndk-26.2.11394342`
+- `34-ndk`, `34-ndk-26.2.11394342`
 
 <details>
 <summary>Deprecated tags</summary>
 
+    - 33-ndk, 33-ndk-26.2.11394342
+    - 32-ndk, 32-ndk-26.2.11394342
     - 33-jdk11-ndk, 33-jdk11-ndk-25.1.8937393
     - 33-ndk-25.1.8937393
     - 32-jdk11-ndk, 32-jdk11-ndk-25.1.8937393

--- a/README.md
+++ b/README.md
@@ -17,23 +17,22 @@ All images are published in [GitHub Container Registry][ghcr].
 >
 > You should always align build-tools and compile SDK in your project to match the versions used in image, otherwise Android Gradle Plugin will download `build-tools` and `platform` packages in each CI build.
 >
-> The build-tools version depends on the image tag: `android-sdk:36` ships build-tools **36.0.0**, `android-sdk:34`, `:33` and `:32` ship build-tools **34.0.0**.
+> All `android-sdk` tags ship the same build-tools **36.0.0** — newer build-tools can build for lower compile SDK levels.
 >
 > ```kotlin
 > android {
->     // 36.0.0 for android-sdk:36, 34.0.0 for android-sdk:34, :33 and :32
 >     buildToolsVersion = "36.0.0"
 >     compileSdk = [x]
 > }
 > ```
+>
+> Keep in mind that Android Gradle Plugin ignores `buildToolsVersion` below its own minimum and downloads its default version instead. AGP 9.2.x defaults to build-tools **36.0.0**.
 
 ### android-sdk:base
 
-> `ghcr.io/redmadrobot/android/android-sdk:base` \
-> `ghcr.io/redmadrobot/android/android-sdk:base-36.0.0`
+> `ghcr.io/redmadrobot/android/android-sdk:base`
 
 Base Android image. All other android images are built on top of this image.
-There are two variants, they differ only in the build-tools version.
 
 **Base image**: `eclipse-temurin:17-jdk-jammy` \
 **Platforms:** `linux/amd64`, `linux/arm64` \
@@ -41,20 +40,16 @@ There are two variants, they differ only in the build-tools version.
 
 - sdkmanager:
     - cmdline-tools **12.0**
-    - build-tools **34.0.0** in `base`, **36.0.0** in `base-36.0.0`
-    - platform-tools — not pinned, an image gets the release current at its build time (**35.0.0** in the published `base`)
+    - build-tools **36.0.0**
+    - platform-tools — not pinned, an image gets the release current at its build time
 - python3 **3.10**
 - git
 - zip, unzip
 
-**Tags:**
-
-- `base` — build-tools **34.0.0**, used by `android-sdk:34`, `:33`, `:32`
-- `base-36.0.0` — build-tools **36.0.0**, used by `android-sdk:36`
-
 <details>
 <summary>Deprecated tags</summary>
 
+    base-36.0.0
     base-jdk11
 
 </details>
@@ -68,16 +63,15 @@ It should match your `compileSdk` in project build script.
 
 **Tags:**
 
-- `36` (Android 16) — built on `base-36.0.0`, build-tools **36.0.0**
+- `36` (Android 16)
+- `35` (Android 15)
 - `34` (Android 14)
-- `33` (Android 13)
-- `32` (Android 12L)
 
 <details>
 <summary>Deprecated tags</summary>
 
-    - 33-jdk11
-    - 32-jdk11
+    - 33, 33-jdk11
+    - 32, 32-jdk11
     - 31, 31-jdk11
     - 30, 30-jdk11
 

--- a/android-emu-atd/Dockerfile
+++ b/android-emu-atd/Dockerfile
@@ -1,18 +1,19 @@
 # syntax=docker/dockerfile:1
 #
-# android-emu-atd — CI-образ для instrumented (UI) тестов через Gradle Managed Devices (GMD).
+# android-emu-atd — CI image for instrumented (UI) tests via Gradle Managed Devices (GMD).
 #
-# В отличие от experimental `android-emu` (ручная модель: запечённый AVD + snapshot +
-# start-emulator, google_apis, один API на образ) — этот образ НЕ бейкает AVD/snapshot:
-# lifecycle эмулятора управляет сама GMD-задача (`:app:ciAtdDebugAndroidTest`). Образ лишь
-# докладывает то, чего нет в android-sdk:36 — рантайм-либы, пакет `emulator` и ATD-образы.
-# Один образ несёт ОБА уровня матрицы (30 x86 + 34 x86_64), чтобы обслуживать её из одного `image:`.
+# Unlike the experimental `android-emu` image (manual model: baked AVD + snapshot +
+# start-emulator, google_apis, one API level per image), this image does NOT bake an
+# AVD/snapshot: the GMD task owns the emulator lifecycle. The image only adds what is
+# missing in android-sdk — emulator runtime libs, the `emulator` package and ATD system
+# images. A single image carries BOTH matrix levels (30 x86 + 34 x86_64), so a device
+# matrix can be served from one `image:`.
 #
-# ATD (Automated Test Device) — headless-оптимизированные образы без Google APIs.
-# /dev/kvm сюда не входит — это проброс устройства на раннере (тег `android`), не часть образа.
+# ATD (Automated Test Device) — system images optimized for headless runs, without Google APIs.
+# /dev/kvm is not part of the image: it is a device passed through on the runner.
 #
-# Список system-images должен совпадать с apiLevel в проекте
-# (app/build.gradle.kts → testOptions.managedDevices: ciAtd=30, ciAtd34=34).
+# The list of system images must match the apiLevel of the managed devices declared by
+# the consuming project (testOptions.managedDevices).
 
 FROM ghcr.io/redmadrobot/android/android-sdk:36
 
@@ -20,7 +21,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN <<EOF
   set -eu
-  # Рантайм-либы эмулятора: без libX11.so.6 лаунчер падает на старте (error loading shared libraries).
+  # Emulator runtime libs: without libX11.so.6 the launcher fails at startup
+  # (error while loading shared libraries).
   apt-get update --yes
   apt-get install --yes --no-install-recommends \
     libx11-6 libx11-xcb1 libxcb1 libxext6 libxdamage1 libxfixes3 \
@@ -31,7 +33,7 @@ EOF
 
 RUN <<EOF
   set -eu
-  # Пакет emulator + ATD system-images под матрицу GMD. Лицензии принимаются здесь же.
+  # The `emulator` package and ATD system images for the GMD matrix. Licenses are accepted here too.
   yes | sdkmanager --licenses > /dev/null
   yes | sdkmanager \
     "emulator" \
@@ -42,8 +44,8 @@ EOF
 
 RUN <<EOF
   set -eu
-  # Build-time sanity: лаунчер линкуется без missing-libs.
-  # (accel-check требует /dev/kvm в рантайме — здесь проверяем только целостность либ.)
+  # Build-time sanity check: the launcher links without missing libs.
+  # (accel-check needs /dev/kvm at runtime, so only lib integrity is verified here.)
   "$ANDROID_HOME/emulator/emulator" -version | head -1
   if ldd "$ANDROID_HOME/emulator/emulator" | grep -q "not found"; then
     echo "ERROR: emulator has missing shared libraries" >&2

--- a/android-emu-atd/Dockerfile
+++ b/android-emu-atd/Dockerfile
@@ -10,7 +10,8 @@
 # matrix can be served from one `image:`.
 #
 # ATD (Automated Test Device) — system images optimized for headless runs, without Google APIs.
-# /dev/kvm is not part of the image: it is a device passed through on the runner.
+# /dev/kvm is not part of the image: the runner must pass the device through
+# (on red_mad_robot CI — the runner tagged `android`).
 #
 # The list of system images must match the apiLevel of the managed devices declared by
 # the consuming project (testOptions.managedDevices).

--- a/android-sdk/Dockerfile
+++ b/android-sdk/Dockerfile
@@ -3,9 +3,12 @@
 FROM eclipse-temurin:17-jdk-jammy AS base
 
 # Specify build tools version.
-# Use the latest available version by default.
+# Newer build tools can build for lower compile SDK levels, so a single version serves all
+# android-sdk tags. Keep it in sync with the default build tools version of the Android Gradle
+# Plugin used by consumers: AGP ignores anything below its minimum and downloads its own default
+# on every build. AGP 9.2.x defaults to 36.0.0.
 # https://developer.android.com/tools/releases/build-tools
-ARG build_tools="34.0.0"
+ARG build_tools="36.0.0"
 ENV ANDROID_BUILD_TOOLS_VERSION=$build_tools
 
 # Define Android environment variables


### PR DESCRIPTION
Follow-up on the two review comments left on #21 after it was merged.

## 1. build-tools in the base image (comment on `android-sdk.yml:101`)

> It makes sense to update build tools in the base image directly. Newer build tools can be used to build for lower SDK level

Agreed, done: `ARG build_tools` in the `base` stage is now `36.0.0`, and the `android-sdk-base-36` / `android-sdk-36` jobs are gone — 36 is a normal matrix entry, so the `36` tag keeps being published.

Supporting numbers for why the separate variant was worth removing: because `base-36.0.0` duplicated the entire base, `android-sdk:36` and `android-sdk:34` shared only **196 MB of 653 MB** of layers (measured from the ghcr manifests). A runner serving both tags kept ~1.1 GB instead of ~0.65 GB.

**Why 36.0.0 and not the latest 37.0.0.** AGP ignores a build-tools version below its own minimum and downloads its default instead — exactly what the old `base` caused on a project with `compileSdk = 36`:

```
WARNING: The specified Android SDK Build Tools version (34.0.0) is ignored, as it is below
the minimum supported version (36.0.0) for Android Gradle Plugin 9.2.1.
Android SDK Build Tools 36.0.0 will be used.
```

AGP 9.2.x defaults to **36.0.0**, so that is the version that avoids a per-build download. Shipping 37.0.0 would put every AGP 9.2.x consumer back into downloading 36.0.0 on each CI job. Happy to bump it once AGP's default moves.

**Heads-up on the breaking part:** this changes `ANDROID_BUILD_TOOLS_VERSION` and `PATH` for *all* `android-sdk` tags. A project that pins `buildToolsVersion = "34.0.0"` will no longer find that directory — pinning a dated tag (`34-20260731`) is the escape hatch. Flagged in the CHANGELOG with `:exclamation:`.

## 2. SDK matrix (comment on `android-sdk.yml:48`)

> Wouldn't it be better to update this value to `[ 35, 36, 37 ]`? (3 latest versions)

Agreed on keeping three latest, but `37` will not build as written, so I went with `[ 34, 35, 36 ]` and left the 37 decision to you. Two reasons:

1. **The package name changed at 37.** There is no flat `platforms;android-37`. Verified against `sdkmanager --list`:

   ```
   platforms;android-36      | 2 | Android SDK Platform 36
   platforms;android-36.1    | 1 | Android SDK Platform 36.1
   platforms;android-37.0    | 2 | Android SDK Platform 37.0
   platforms;android-37.1    | 1 | Android SDK Platform 37.1
   platforms;android-37.2-beta1
   ```

   So the matrix entry has to be `37.0` (or `37.1`), which also decides the image tag name — `37.0` and `37.0-ndk` rather than `37`. Worth a deliberate choice rather than my guess.
2. **A 37 image wants build-tools 37.0.0**, which conflicts with keeping the base at 36.0.0 for AGP 9.2.x consumers (see above). Adding 37 is coupled to that decision.

`34` is kept for now because projects still build against it; say the word and I'll make it `[ 35, 36, 37.0 ]` with build-tools 37.0.0 in the same PR.

## 3. Comments in English (separate commit)

`android-emu-atd/Dockerfile` and its workflow landed in #20 with Russian comments while the rest of the repo is in English — translated. Two lines that only made sense before the files were added here are dropped, and the system-image note no longer points at a specific consumer project. Separate commit, drop it if you'd rather keep this PR to one topic.

## Not included, your call

While measuring the pull cost of these images I found two things outside the scope of the review comments:

- `publish-image.yml` calls `docker/build-push-action` without `cache-from`/`cache-to`, so every dispatch rebuilds all `RUN` layers and changes the digest. `android-emu-atd:36` and `:34` share **0 MB** of layers despite identical apt/sdkmanager steps, and consumers re-pull the whole image. The trade-off is that caching apt layers means a rebuild no longer picks up upstream package updates, which for a manually dispatched publish workflow may be the wrong default — so I did not touch it.
- `on: workflow_dispatch` has no per-job gating, so publishing one tag republishes `base` and every SDK/NDK tag with a fresh `-YYYYMMDD`. Much less of an issue now that the parallel 36 pipeline is gone.

Both are easy to add if you want them.

## Verification

Not dispatched — publishing is a maintainer action. Checked locally: both workflow files parse, the matrices resolve to `[34, 35, 36]`, the only remaining mentions of `base-36.0.0` are the CHANGELOG entry and the README deprecated-tags list, and `android-emu-atd/Dockerfile` still builds `FROM android-sdk:36`, a tag this PR keeps publishing.

