### PR TITLE
version: 2026.08.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2026.08.05]
+
 ### android-sdk
 
 - Add image for Android SDK 36 (Android 16): `android-sdk:36`, `android-sdk:36-ndk`
@@ -68,6 +70,7 @@
 - Add ruby 3.2 image
 - Remove redundant environment variables
 
-[unreleased]: https://github.com/RedMadRobot/android-docker-images/compare/2024.02.24..main
+[unreleased]: https://github.com/RedMadRobot/android-docker-images/compare/2026.08.05..main
+[2026.08.05]: https://github.com/RedMadRobot/android-docker-images/compare/2024.02.24..2026.08.05
 [2024.02.24]: https://github.com/RedMadRobot/android-docker-images/compare/2023.04.19..2024.02.24
 [2023.04.19]: https://github.com/RedMadRobot/android-docker-images/compare/2023.01.16..2023.04.19


### PR DESCRIPTION
Cuts the release section for the images published today, following the convention of `dada54c` (`version: 2024.02.24`): dated header below an empty `[Unreleased]`, plus the compare links.

The publish already ran, so the section describes what is actually in ghcr — not a plan:

- `Android SDK Images` — [run 31006017446](https://github.com/RedMadRobot/android-docker-images/actions/runs/31006017446), success. New tags: `35`, `35-ndk`, `36-ndk`, plus `base`, `34`, `36` and every `-ndk` variant refreshed as `-20260805`. `32` and `33` were not rebuilt, which is the archival this release announces.
- The republished `base` carries the build-tools bump — `ANDROID_BUILD_TOOLS_VERSION=36.0.0` in the amd64 image config, created `2026-08-05T12:33:11Z`.
- `Android Emulator ATD Image` — [run 31006916391](https://github.com/RedMadRobot/android-docker-images/actions/runs/31006916391), rebuilding `android-emu-atd:36` on the fresh `android-sdk:36`.

Only `CHANGELOG.md` changes here. The `2026.08.05` git tag is a maintainer step — it belongs on this commit once merged, the same way `2024.02.24` sits on `dada54c`.