### PR TITLE
android-emu-atd: bake ATD 31 and google_apis 37.0 system images

### DIFF
--- a/.github/workflows/android-emu-atd.yml
+++ b/.github/workflows/android-emu-atd.yml
@@ -1,6 +1,6 @@
-# platforms=linux/amd64: the emulator and ATD system images are x86/x86_64, arm64 is not needed.
+# platforms=linux/amd64: the emulator and the system images are x86/x86_64, arm64 is not needed.
 # The image tag is the base android-sdk version (36), not the API level of the bundled
-# ATD system images (30 + 34).
+# system images (30, 31, 34, 37.0).
 name: Android Emulator ATD Image
 on: workflow_dispatch
 
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/publish-image.yml
     with:
       image-name: android-emu-atd
-      title: Android Emulator ATD image (GMD, base android-sdk:36, ATD API 30 + 34)
+      title: Android Emulator ATD image (GMD, base android-sdk:36, ATD API 30 + 31 + 34, google_apis API 37.0)
       platforms: linux/amd64
       tags: |
         36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### android-emu-atd
 
+- Bake two more system images into `android-emu-atd:36`: `system-images;android-31;aosp_atd;x86_64` and `system-images;android-37.0;google_apis;x86_64`. Gradle Managed Devices on API 31 and 37 no longer download a system image in every CI build. The already bundled API 30 and 34 ATD images are kept
+- API 37 uses a regular `google_apis` image because ATD is published up to `android-36` only — such a device needs `systemImageSource = "google"` in the managed devices config, while the ATD levels keep `"aosp-atd"`. It is also much larger than an ATD image, so the pull of `android-emu-atd:36` grows accordingly
 - Add experimental `android-emu-atd:36` image — Android emulator for instrumented tests via Gradle Managed Devices (AOSP ATD system images API 30 + 34, emulator runtime libs). Unlike `android-emu`, does not bake an AVD/snapshot; GMD manages the emulator lifecycle
 - :exclamation: Base image `android-sdk:34` → `android-sdk:36`. The published tag is renamed `34` → `36` accordingly: the tag denotes the base `android-sdk` version, not an ATD API level. Bundled ATD system images are unchanged (API 30 + 34)
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Ruby image with some additions to work with Fastlane and Danger.
 
 > [!Note]
 >
-> The image tag is the version of the base `android-sdk` image, **not** an ATD API level.
-> `android-emu-atd:36` is built on `android-sdk:36` and carries ATD system images for API **30** and **34**.
+> The image tag is the version of the base `android-sdk` image, **not** an API level.
+> `android-emu-atd:36` is built on `android-sdk:36` and carries system images for API **30**, **31**, **34** and **37.0**.
 
 Image for instrumented (UI) tests run via **Gradle Managed Devices (GMD)**.
 Unlike `android-emu` (manual model: baked AVD + snapshot + `start-emulator`, `google_apis`,
@@ -192,11 +192,25 @@ manages the emulator lifecycle. It only adds what stock `android-sdk` lacks:
 
 - emulator runtime shared libraries (`libX11` etc. — the launcher fails to start without them);
 - the `emulator` package;
-- AOSP **ATD** system images (headless-optimized, no Google APIs):
-  `system-images;android-30;aosp_atd;x86` and `system-images;android-34;aosp_atd;x86_64`.
+- system images:
+    - AOSP **ATD** (headless-optimized, no Google APIs) — GMD `systemImageSource = "aosp-atd"`:
+      `system-images;android-30;aosp_atd;x86`, `system-images;android-31;aosp_atd;x86_64`,
+      `system-images;android-34;aosp_atd;x86_64`
+    - **Google APIs** — GMD `systemImageSource = "google"`:
+      `system-images;android-37.0;google_apis;x86_64`
 
-A single image carries both API levels so it serves the whole GMD matrix from one `image:`.
-The API levels must match `apiLevel` in the consuming project's Gradle Managed Devices config.
+A single image carries every API level so it serves the whole GMD matrix from one `image:`.
+
+> [!Note]
+>
+> Two quirks of the package ids above, both checked against `sdkmanager --list`:
+> API 31 has no 32-bit `x86` ATD image (`x86` ATD stops at API 30), and ATD is published up to
+> `android-36` only — so API 37 uses a regular, noticeably larger `google_apis` image.
+> Mind the minor version: there is no flat `android-37` in system images, only `android-37.0`.
+
+Both `apiLevel` **and** `systemImageSource` of every managed device in the consuming project must
+match one of the packages above. On a mismatch the Gradle Managed Devices task downloads its own
+system image on every build, which is exactly what baking them into the image avoids.
 
 > [!Note]
 >

--- a/android-emu-atd/Dockerfile
+++ b/android-emu-atd/Dockerfile
@@ -5,16 +5,19 @@
 # Unlike the experimental `android-emu` image (manual model: baked AVD + snapshot +
 # start-emulator, google_apis, one API level per image), this image does NOT bake an
 # AVD/snapshot: the GMD task owns the emulator lifecycle. The image only adds what is
-# missing in android-sdk — emulator runtime libs, the `emulator` package and ATD system
-# images. A single image carries BOTH matrix levels (30 x86 + 34 x86_64), so a device
+# missing in android-sdk — emulator runtime libs, the `emulator` package and the system
+# images. A single image carries EVERY matrix level (30, 31, 34, 37.0), so a device
 # matrix can be served from one `image:`.
 #
 # ATD (Automated Test Device) — system images optimized for headless runs, without Google APIs.
+# Google publishes ATD up to android-36 only, so API 37.0 falls back to a regular
+# `google_apis` image: bigger and not headless-optimized, but the only x86_64 option there.
 # /dev/kvm is not part of the image: the runner must pass the device through
 # (on red_mad_robot CI — the runner tagged `android`).
 #
-# The list of system images must match the apiLevel of the managed devices declared by
-# the consuming project (testOptions.managedDevices).
+# The list of system images must match both the apiLevel and the systemImageSource of the
+# managed devices declared by the consuming project (testOptions.managedDevices):
+# `aosp-atd` for the ATD levels, `google` for 37.0.
 
 FROM ghcr.io/redmadrobot/android/android-sdk:36
 
@@ -34,12 +37,16 @@ EOF
 
 RUN <<EOF
   set -eu
-  # The `emulator` package and ATD system images for the GMD matrix. Licenses are accepted here too.
+  # The `emulator` package and the system images for the GMD matrix. Licenses are accepted here too.
+  # Package ids are exact: API 31 has no 32-bit x86 ATD image (x86 ATD stops at API 30),
+  # and 37.0 keeps its minor version — there is no flat `android-37` in system-images.
   yes | sdkmanager --licenses > /dev/null
   yes | sdkmanager \
     "emulator" \
     "system-images;android-30;aosp_atd;x86" \
-    "system-images;android-34;aosp_atd;x86_64"
+    "system-images;android-31;aosp_atd;x86_64" \
+    "system-images;android-34;aosp_atd;x86_64" \
+    "system-images;android-37.0;google_apis;x86_64"
   rm -rf "$ANDROID_USER_HOME/cache"
 EOF
 


### PR DESCRIPTION
`android-emu-atd:36` bakes ATD system images for API **30** and **34**. A consuming project ([android/shared-libraries!43](https://git.redmadrobot.com/android/shared-libraries/-/merge_requests/43)) moves its Gradle Managed Devices matrix to **31 + 37**, and neither baked image covers that — so every UI job downloads its own system image again, which is exactly the cost baking removes.

Adds two packages, keeps the existing two.

```
system-images;android-31;aosp_atd;x86_64
system-images;android-37.0;google_apis;x86_64
```

### Two quirks worth reviewing

- **API 31 has no 32-bit `x86` ATD image** — `x86` ATD stops at API 30, so 31 is `x86_64` only. A managed device on it needs `testedAbi = "x86_64"`.
- **ATD is published up to `android-36` only.** Neither `aosp_atd` nor `google_atd` exists for API 37, so 37 takes a regular `google_apis` image. Two consequences: a managed device on it needs `systemImageSource = "google"` instead of `"aosp-atd"`, and the image is noticeably larger and not headless-optimized — the pull of `android-emu-atd:36` grows.

Also note the minor version: there is no flat `android-37` in system images, only `android-37.0`. Package ids were checked against `sdkmanager --list` of the same cmdline-tools the image ships; both sit behind `android-sdk-license`, already accepted in that layer.

API 30 and 34 are kept — other projects may still pin them. Dropping them is a separate decision about image size.

### Not verified here

The image was not built locally — the change is a package-list edit plus docs. The real check is a `workflow_dispatch` run of `Android Emulator ATD Image` and a UI job on the result.

### Interaction with #23

#23 cuts the current `[Unreleased]` into a dated `2026.08.05` section for what is already published. This change is **not** published yet, so its entry stays under `[Unreleased]`. Whichever merges second will hit a `CHANGELOG.md` conflict — resolve by keeping this `### android-emu-atd` entry in `[Unreleased]` and letting the older bullets go into the dated section.
